### PR TITLE
Assume a Single if track_num is None and set to 1

### DIFF
--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -250,7 +250,12 @@ class Bandcamper:
         file_paths = []
         for track in track_info:
             if track.get("file"):
-                track_num = f"{track['track_num'] or 0:02d}"
+                
+                if track["track_num"] is None:
+                    track_num = 1
+                else:
+                    track_num = f"{track['track_num']:02d}"
+
                 if title is None:
                     title = track["title"]
                 file_paths.append(


### PR DESCRIPTION
When a single track is found in a URL such as this one:

&emsp; https://acidwaxa.bandcamp.com/track/1-2-3-4-505-2
 
The track numbering returns None causing an error in the fallback mp3 download. 

The patch makes an assumption that it is a single and assigns the value 1 as the track number