### PR TITLE
Fix occasional `NoneType` exceptions and `--no-fallback` argument

### DIFF
--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -138,7 +138,7 @@ class Bandcamper:
                 raise ValueError(f"{url} not found")
             raise exc
         else:
-            soup = BeautifulSoup(response.content, "lxml")
+            soup = BeautifulSoup(response.text, "lxml")
             data = json.loads(
                 soup.find("script", {"data-tralbum": True})["data-tralbum"]
             )

--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -328,6 +328,8 @@ class Bandcamper:
                 music_data["trackinfo"], artist, album, title, destination
             )
             download_mp3 = False
+        elif not self.fallback:
+            return
         else:
             raise ValueError(
                 f"No free download found for {url}. Try setting fallback to True."


### PR DESCRIPTION
8851f81aba441af7b548f323c30df6c44c7d6b26 - I was encountering `NoneType` errors mention in #5 - the issue was that sometimes when the response was interpreted as binary rather than text it would not contain the entire response.

4d759f62b2a48fec9aec9b9426694f070d0c0d8a - The other fix is with `--no-fallback`, I may be interpreting it wrong but my assumption is that while downloading an artists' page that it would skip over paid tracks rather than erroring out.