### PR TITLE
Add `_upper` modifier for customized file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The output template is a string that can contain special variables and will be j
 
 This template follows the Python string formatting scheme of `{var}` and is, by default, `"{artist}/{album}/{track_num:02d} - {track}.{ext}"`. You can change the template through the -o/--output flag.
 
-Adding `_upper` to end of the variable name will insert the variable upper-cased.
+Two output operators are implemented; `u` and `l` which format the variable to all upper-case or all lower-case respectively. These are used with `{var:format}` where `format` is either of the format characters.
 
 These are the available variables you can use in the template:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The output template is a string that can contain special variables and will be j
 
 This template follows the Python string formatting scheme of `{var}` and is, by default, `"{artist}/{album}/{track_num:02d} - {track}.{ext}"`. You can change the template through the -o/--output flag.
 
+Adding `_upper` to end of the variable name will insert the variable upper-cased.
+
 These are the available variables you can use in the template:
 
 | Variable  | Description                |

--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -17,6 +17,7 @@ from bandcamper.metadata.utils import get_track_output_context
 from bandcamper.metadata.utils import suffix_to_metadata
 from bandcamper.requests.requester import Requester
 from bandcamper.screamo import Screamer
+from bandcamper.utils import FilenameFormatter
 from bandcamper.utils import get_random_filename_template
 
 
@@ -74,6 +75,7 @@ class Bandcamper:
         self.urls = set()
         self.fallback = fallback
         self.force_https = force_https
+        self.formatter = FilenameFormatter()
         self.screamer = screamer or Screamer()
         self.requester = requester or Requester()
         for url in urls:
@@ -241,11 +243,9 @@ class Bandcamper:
         else:
             output = output_extra
             context["filename"] = file_path.name
-        # create _upper variants for all string values
-        for k, v in dict(context).items():
-            if isinstance(v, str):
-                context[k + "_upper"] = v.upper()
-        move_to = self._sanitize_file_path(destination / output.format(**context))
+        move_to = self._sanitize_file_path(
+            destination / self.formatter.format(output, **context)
+        )
         move_to.parent.mkdir(parents=True, exist_ok=True)
         file_path.replace(move_to)
         return move_to

--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -241,6 +241,10 @@ class Bandcamper:
         else:
             output = output_extra
             context["filename"] = file_path.name
+        # create _upper variants for all string values
+        for k, v in dict(context).items():
+            if isinstance(v, str):
+                context[k + "_upper"] = v.upper()
         move_to = self._sanitize_file_path(destination / output.format(**context))
         move_to.parent.mkdir(parents=True, exist_ok=True)
         file_path.replace(move_to)

--- a/bandcamper/utils.py
+++ b/bandcamper/utils.py
@@ -1,5 +1,29 @@
+from string import Formatter
 from uuid import uuid4
 
 
 def get_random_filename_template():
     return uuid4().hex[:16] + "{ext}"
+
+
+class FilenameFormatter(Formatter):
+    """
+    Custom formatter for modifying user-defined output.
+    Reference: https://peps.python.org/pep-3101
+
+    Two formatters are implemented:
+        1. :u - uppercase
+        2. :l - lowercase
+    """
+
+    def format_field(self, value, format_spec: str):
+        if isinstance(value, str):
+            # format string based on provided modifier and remove modifier character from format string
+            # before continuing
+            if format_spec.endswith("u"):
+                value = value.upper()
+                format_spec = format_spec[:-1]
+            elif format_spec.endswith("l"):
+                value = value.lower()
+                format_spec = format_spec[:-1]
+        return super().format_field(value, format_spec)


### PR DESCRIPTION
This adds an uppercased variant to all track context variables allowing `--output` to be supplied with a variable such as `{ext_upper}`, where the output file would contain an upper-cased version of the requested variable.

e.g:
`{artist} - {album} ({year}) [{ext_upper}])`
would output:
`Agoraphobic - IV (2023) [FLAC]`
