### PR TITLE
Fix issue with single track releases having no album name and a track number of 0

### DIFF
--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -289,11 +289,8 @@ class Bandcamper:
             self.screamer.error(f"Failed to get music data from {url}")
             return
 
-        tracks = {
-            track["track_num"]: track["title"] for track in music_data["trackinfo"]
-        }
         artist = music_data["artist"]
-        title = music_data["current"]["title"]
+        title = album = music_data["current"]["title"]
         year = (
             music_data["current"].get("release_date")
             or music_data["current"]["publish_date"]
@@ -301,10 +298,18 @@ class Bandcamper:
 
         downloading_str = f"Downloading {artist} - {title}"
         if music_data["item_type"] == "album":
-            album = title
             title = None
+        elif music_data["item_type"] == "track":
+            # set track num as it is None for single tracks
+            music_data["trackinfo"][0]["track_num"] = 1
         else:
-            album = music_data.get("album_title", "")
+            raise NotImplementedError(
+                "Release is of an unknown type (only albums and tracks are supported)."
+            )
+
+        tracks = {
+            track["track_num"]: track["title"] for track in music_data["trackinfo"]
+        }
 
         if music_data.get("freeDownloadPage"):
             self.screamer.success(f"Free download found! {downloading_str}")

--- a/bandcamper/metadata/utils.py
+++ b/bandcamper/metadata/utils.py
@@ -43,7 +43,7 @@ def get_track_output_context(track_path, tracks):
     file_path = Path(track_metadata.file.filename)
     filename_data = parse_filename(file_path.name)
     track_number = track_metadata.track_number or int(
-        filename_data.get("track_number", 0)
+        filename_data.get("track_number", 1)
     )
     track_title = (
         tracks.get(track_number)


### PR DESCRIPTION
Single track release metadata isn't properly handled, and the provided track number is `None` so breaks the dict comprehension. Seems they might have changed the name of `album_title` to just `title`. These changes explicitly handle albums and tracks, not sure if there are any other types of releases but these will raise a `NotImplementedError` if encountered.