### PR TITLE
Add `ext` as possible option with `--otherdir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ These are the available variables you can use in the template:
 | artist    | The artist's name          |
 | filename  | The name of the file       |
 | year      | The album's release year   |
-
+| ext       | The album's file extension |
 
 ### Examples
 

--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -347,7 +347,11 @@ class Bandcamper:
         }
         for file_path in file_paths:
             if file_path.is_dir():
-                for track_path in file_path.iterdir():
+                dir_contents = list(file_path.iterdir())
+                context["ext"] = get_track_output_context(dir_contents[-1], tracks)[
+                    "ext"
+                ]
+                for track_path in dir_contents:
                     new_path = self.move_file(
                         track_path, destination, output, output_extra, tracks, context
                     )


### PR DESCRIPTION
This PR allows the use of `{ext}` with `--otherdir`. This is done by grabbing the extension from the last track inside the album directory and using its' metadata as albums can only be downloaded in one format (as far as I'm aware). Not sure if there's a better way of doing this but I'm open to anything.

Also wanted to bring something else up with `--output`.  By default if using just `--output` you end up with a spam of extra folders containing just album covers (due to the `--otherdir` default). I think it would be nice to clean these up automatically, potentially by removing the extra files if `--output` is provided but not `--otherdir`, or try and create a `--otherdir` based on the provided `--output` format.

Again thanks for making this project!