### PR TITLE
Fix email download being seen as free if price is added after upload

### DIFF
--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -310,26 +310,29 @@ class Bandcamper:
         else:
             album = music_data.get("album_title", "")
 
-        if not music_data["current"].get("minimum_price"):
-            if music_data.get("freeDownloadPage"):
-                self.screamer.success(f"Free download found! {downloading_str}")
-                file_paths = self._free_download(
-                    music_data["freeDownloadPage"],
-                    destination,
-                    music_data["item_type"],
-                    *download_formats,
-                )
-            elif music_data["current"].get("require_email"):
-                self.screamer.success(f"Email download found! {downloading_str}")
-                download_url = self._get_download_url_from_email(
-                    url, music_data["id"], music_data["item_type"]
-                )
-                file_paths = self._free_download(
-                    download_url,
-                    destination,
-                    music_data["item_type"],
-                    *download_formats,
-                )
+        if music_data.get("freeDownloadPage") and not music_data["current"].get(
+            "minimum_price"
+        ):
+            self.screamer.success(f"Free download found! {downloading_str}")
+            file_paths = self._free_download(
+                music_data["freeDownloadPage"],
+                destination,
+                music_data["item_type"],
+                *download_formats,
+            )
+        elif music_data["current"].get("require_email") and not music_data[
+            "current"
+        ].get("minimum_price"):
+            self.screamer.success(f"Email download found! {downloading_str}")
+            download_url = self._get_download_url_from_email(
+                url, music_data["id"], music_data["item_type"]
+            )
+            file_paths = self._free_download(
+                download_url,
+                destination,
+                music_data["item_type"],
+                *download_formats,
+            )
         elif self.fallback or download_mp3:
             self.screamer.success(f"MP3-128 download found! {downloading_str}")
             file_paths = self.download_fallback_mp3(

--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -250,7 +250,6 @@ class Bandcamper:
         file_paths = []
         for track in track_info:
             if track.get("file"):
-                
                 if track["track_num"] is None:
                     track_num = 1
                 else:
@@ -311,22 +310,26 @@ class Bandcamper:
         else:
             album = music_data.get("album_title", "")
 
-        if music_data.get("freeDownloadPage"):
-            self.screamer.success(f"Free download found! {downloading_str}")
-            file_paths = self._free_download(
-                music_data["freeDownloadPage"],
-                destination,
-                music_data["item_type"],
-                *download_formats,
-            )
-        elif music_data["current"].get("require_email"):
-            self.screamer.success(f"Email download found! {downloading_str}")
-            download_url = self._get_download_url_from_email(
-                url, music_data["id"], music_data["item_type"]
-            )
-            file_paths = self._free_download(
-                download_url, destination, music_data["item_type"], *download_formats
-            )
+        if not music_data["current"].get("minimum_price"):
+            if music_data.get("freeDownloadPage"):
+                self.screamer.success(f"Free download found! {downloading_str}")
+                file_paths = self._free_download(
+                    music_data["freeDownloadPage"],
+                    destination,
+                    music_data["item_type"],
+                    *download_formats,
+                )
+            elif music_data["current"].get("require_email"):
+                self.screamer.success(f"Email download found! {downloading_str}")
+                download_url = self._get_download_url_from_email(
+                    url, music_data["id"], music_data["item_type"]
+                )
+                file_paths = self._free_download(
+                    download_url,
+                    destination,
+                    music_data["item_type"],
+                    *download_formats,
+                )
         elif self.fallback or download_mp3:
             self.screamer.success(f"MP3-128 download found! {downloading_str}")
             file_paths = self.download_fallback_mp3(


### PR DESCRIPTION
Encountered an issue with email downloads if a price is set after the release was uploaded as free.

The email download would process as if it was available before halting with ```ValueError: Email download request failed: {"ok":false,"error":"Sorry, this item is no longer available for free."}```

This change checks that the `minimum_price` is 0. I'm not sure if tracks and non-email downloads have this issue but I added the check for all types just in case.

_Force-pushes were to cover potential edge cases I forgot and cover both albums and tracks all in one_