### PR TITLE
slash replacement support (fix yyyyyyyan/bandcamper#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Options:
     --output-extra TEMPLATE       Output filename template for extra files.
                                   See the 'Extra Output Template' section of
                                   the README for all the info
+    -s, --slash-replacement STRING
+                                  Replace slashes in output filenames with
+                                  this string. Defaults to '.'
   Request Options:
     --random-user-agent           Use random User-Agent for Bandcamp requests
     --http-proxy URL              Proxy to use for HTTP connections

--- a/bandcamper/__main__.py
+++ b/bandcamper/__main__.py
@@ -77,6 +77,13 @@ def configure(ctx, param, config_path=None):
     default="{artist}/{album}/{filename}",
     help="Output filename template for extra files. See the 'Extra Output Template' section of the README for all the info",
 )
+@optgroup.option(
+    "-s",
+    "--slash-replacement",
+    metavar="STRING",
+    default=".",
+    help="Replace slashes in output filenames with this string. Defaults to '.'",
+)
 @optgroup.group("Request Options")
 @optgroup.option(
     "--random-user-agent",
@@ -138,6 +145,7 @@ def main(
     destination,
     output,
     output_extra,
+    slash_replacement,
     random_user_agent,
     http_proxy,
     https_proxy,
@@ -166,6 +174,7 @@ def main(
         force_https=force_https,
         screamer=screamer,
         requester=requester,
+        slash_replacement=slash_replacement,
     )
     for url in urls:
         try:

--- a/bandcamper/bandcamper.py
+++ b/bandcamper/bandcamper.py
@@ -71,6 +71,7 @@ class Bandcamper:
         force_https=True,
         screamer=None,
         requester=None,
+        slash_replacement='.',
     ):
         self.urls = set()
         self.fallback = fallback
@@ -78,6 +79,7 @@ class Bandcamper:
         self.formatter = FilenameFormatter()
         self.screamer = screamer or Screamer()
         self.requester = requester or Requester()
+        self.slash_replacement = slash_replacement
         for url in urls:
             self.add_url(url)
 
@@ -239,7 +241,7 @@ class Bandcamper:
 
     def move_file(self, file_path, destination, output, output_extra, tracks, context):
         if file_path.suffix in suffix_to_metadata:
-            context.update(get_track_output_context(file_path, tracks))
+            context.update(get_track_output_context(file_path, tracks, self.slash_replacement))
         else:
             output = output_extra
             context["filename"] = file_path.name
@@ -266,7 +268,7 @@ class Bandcamper:
                     self.requester.download_to_file(
                         track["file"]["mp3-128"],
                         destination,
-                        f"{artist} - {album} - {track_num} {title}{{ext}}",
+                        f"{artist} - {album} - {track_num} {title}{{ext}}".replace("/", self.slash_replacement),
                         f"{track_num}.mp3",
                     )
                 )
@@ -352,9 +354,9 @@ class Bandcamper:
             )
 
         context = {
-            "artist": artist,
-            "album": album,
-            "year": year,
+            "artist": artist.replace('/', self.slash_replacement),
+            "album": album.replace('/', self.slash_replacement),
+            "year": year.replace('/', self.slash_replacement),
         }
         for file_path in file_paths:
             if file_path.is_dir():

--- a/bandcamper/metadata/utils.py
+++ b/bandcamper/metadata/utils.py
@@ -38,7 +38,7 @@ def parse_filename(filename):
     return match.groupdict()
 
 
-def get_track_output_context(track_path, tracks):
+def get_track_output_context(track_path, tracks, slash_replacement):
     track_metadata = get_track_metadata(track_path)
     file_path = Path(track_metadata.file.filename)
     filename_data = parse_filename(file_path.name)
@@ -51,7 +51,7 @@ def get_track_output_context(track_path, tracks):
         or filename_data.get("title", "")
     )
     context = {
-        "track": track_title,
+        "track": track_title.replace("/", slash_replacement),
         "track_num": track_number,
         "ext": file_path.suffix.split(".")[-1],
     }


### PR DESCRIPTION
#11 gets reverted by #16.
This commit also did a slash replacement that #11 overlooked.

Supersedes #20 (because [pull](https://github.com/apps/pull) fucked up the main branch in my fork).